### PR TITLE
fix : 🐛 remove false positives from EC69

### DIFF
--- a/src/main/java/fr/greencodeinitiative/java/checks/NoFunctionCallWhenDeclaringForLoop.java
+++ b/src/main/java/fr/greencodeinitiative/java/checks/NoFunctionCallWhenDeclaringForLoop.java
@@ -17,7 +17,6 @@
  */
 package fr.greencodeinitiative.java.checks;
 
-import java.nio.file.WatchEvent.Kind;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -27,18 +26,15 @@ import java.util.Map;
 
 import org.sonar.check.Rule;
 import org.sonar.plugins.java.api.IssuableSubscriptionVisitor;
-import org.sonar.plugins.java.api.semantic.Type;
 import org.sonar.plugins.java.api.tree.BaseTreeVisitor;
 import org.sonar.plugins.java.api.tree.ClassTree;
 import org.sonar.plugins.java.api.tree.CompilationUnitTree;
 import org.sonar.plugins.java.api.tree.ExpressionTree;
 import org.sonar.plugins.java.api.tree.ForStatementTree;
 import org.sonar.plugins.java.api.tree.IdentifierTree;
-import org.sonar.plugins.java.api.tree.MemberSelectExpressionTree;
 import org.sonar.plugins.java.api.tree.MethodInvocationTree;
 import org.sonar.plugins.java.api.tree.PackageDeclarationTree;
 import org.sonar.plugins.java.api.tree.Tree;
-import org.sonar.plugins.java.api.tree.TypeArguments;
 import org.sonarsource.analyzer.commons.annotations.DeprecatedRuleKey;
 
 @Rule(key = "EC69")
@@ -63,7 +59,6 @@ public class NoFunctionCallWhenDeclaringForLoop extends IssuableSubscriptionVisi
             method.condition().accept(invocationMethodVisitor);
         }
         // update
-        // initaliser
         method.update().accept(invocationMethodVisitor);
     }
 

--- a/src/main/java/fr/greencodeinitiative/java/checks/NoFunctionCallWhenDeclaringForLoop.java
+++ b/src/main/java/fr/greencodeinitiative/java/checks/NoFunctionCallWhenDeclaringForLoop.java
@@ -81,7 +81,6 @@ public class NoFunctionCallWhenDeclaringForLoop extends IssuableSubscriptionVisi
         private boolean isIteratorMethod(MethodInvocationTree tree) {
             boolean isIterator = tree.methodSymbol().owner().type().isSubtypeOf("java.util.Iterator");
             String methodName = tree.methodSelect().lastToken().text();
-            System.out.println("methodName: " + methodName + " isIterator: " + isIterator);
             boolean isMethodNext = methodName.equals("next");
             boolean isMethodHasNext = methodName.equals("hasNext");
             return isIterator && (isMethodNext || isMethodHasNext);

--- a/src/test/files/NoFunctionCallWhenDeclaringForLoop.java
+++ b/src/test/files/NoFunctionCallWhenDeclaringForLoop.java
@@ -15,6 +15,10 @@
  * You should have received a copy of the GNU General Public License
  * along with this program. If not, see <http://www.gnu.org/licenses/>.
  */
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Arrays;
 class NoFunctionCallWhenDeclaringForLoop {
     NoFunctionCallWhenDeclaringForLoop(NoFunctionCallWhenDeclaringForLoop mc) {
     }
@@ -30,7 +34,7 @@ class NoFunctionCallWhenDeclaringForLoop {
     public void test1() {
         for (int i = 0; i < 20; i++) {
             System.out.println(i);
-            boolean b = getMyValue() > 6;
+            boolean b = this.getMyValue() > 6;
         }
     }
 
@@ -42,8 +46,9 @@ class NoFunctionCallWhenDeclaringForLoop {
 
     }
 
+    // compliant, the function is called only once in the initialization so it's not a performance issue
     public void test3() {
-        for (int i = getMyValue(); i < 20; i++) {  // Noncompliant {{Do not call a function when declaring a for-type loop}}
+        for (int i = getMyValue(); i < 20; i++) {
             System.out.println(i);
             boolean b = getMyValue() > 6;
         }
@@ -70,13 +75,42 @@ class NoFunctionCallWhenDeclaringForLoop {
         }
     }
 
+    // compliant, iterators are allowed to be called in a for loop
     public void test7() {
         List<String> joursSemaine = Arrays.asList("Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche");
         
         String jour;
+        // iterator
         for (Iterator<String> iterator = joursSemaine.iterator(); iterator.hasNext(); jour = iterator.next()) {
             System.out.println(jour);
         }
+
+        // subclass of iterator
+        for (ListIterator<String> iterator = joursSemaine.listIterator(); iterator.hasNext(); jour = iterator.next()) {
+            System.out.println(jour);
+        }
+
+        // iterator called in an indirect way
+        for (OtherClassWithIterator otherClass = new OtherClassWithIterator(joursSemaine); otherClass.iterator.hasNext(); jour = otherClass.iterator.next()) {
+            System.out.println(jour);
+        }
+
+        for (OtherClassWithIterator otherClass = new OtherClassWithIterator(joursSemaine); otherClass.getIterator().hasNext(); jour = otherClass.getIterator().next()) {  // Noncompliant {{Do not call a function when declaring a for-type loop}}
+            System.out.println(jour);
+        }
+
     }
 
+}
+
+class OtherClassWithIterator {
+    public Iterator<String> iterator;
+
+    public OtherClassWithIterator(Iterator<String> iterator){
+        this.iterator = iterator;
+    }
+
+    public Iterator getIterator(){
+        return iterator;
+    }
 }

--- a/src/test/files/NoFunctionCallWhenDeclaringForLoop.java
+++ b/src/test/files/NoFunctionCallWhenDeclaringForLoop.java
@@ -72,10 +72,10 @@ class NoFunctionCallWhenDeclaringForLoop {
 
     public void test7() {
         List<String> joursSemaine = Arrays.asList("Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche");
-        Iterator<String> iterator = joursSemaine.iterator();
-
-        for (String jour : iterator.hasNext()) {
-            String jour = iterator.next();
+        
+        String jour;
+        for (Iterator<String> iterator = joursSemaine.iterator(); iterator.hasNext(); jour = iterator.next()) {
+            System.out.println(jour);
         }
     }
 

--- a/src/test/files/NoFunctionCallWhenDeclaringForLoop.java
+++ b/src/test/files/NoFunctionCallWhenDeclaringForLoop.java
@@ -70,4 +70,13 @@ class NoFunctionCallWhenDeclaringForLoop {
         }
     }
 
+    public void test7() {
+        List<String> joursSemaine = Arrays.asList("Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche");
+        Iterator<String> iterator = joursSemaine.iterator();
+
+        for (String jour : iterator.hasNext()) {
+            String jour = iterator.next();
+        }
+    }
+
 }

--- a/src/test/files/NoFunctionCallWhenDeclaringForLoop.java
+++ b/src/test/files/NoFunctionCallWhenDeclaringForLoop.java
@@ -80,21 +80,21 @@ class NoFunctionCallWhenDeclaringForLoop {
         List<String> joursSemaine = Arrays.asList("Lundi", "Mardi", "Mercredi", "Jeudi", "Vendredi", "Samedi", "Dimanche");
         
         String jour;
-        // iterator
+        // iterator is allowed
         for (Iterator<String> iterator = joursSemaine.iterator(); iterator.hasNext(); jour = iterator.next()) {
             System.out.println(jour);
         }
 
-        // subclass of iterator
+        // subclass of iterator is allowed
         for (ListIterator<String> iterator = joursSemaine.listIterator(); iterator.hasNext(); jour = iterator.next()) {
             System.out.println(jour);
         }
 
-        // iterator called in an indirect way
+        // iterator called in an indirect way is allowed
         for (OtherClassWithIterator otherClass = new OtherClassWithIterator(joursSemaine); otherClass.iterator.hasNext(); jour = otherClass.iterator.next()) {
             System.out.println(jour);
         }
-
+        // but using a method that returns an iterator causes an issue
         for (OtherClassWithIterator otherClass = new OtherClassWithIterator(joursSemaine); otherClass.getIterator().hasNext(); jour = otherClass.getIterator().next()) {  // Noncompliant {{Do not call a function when declaring a for-type loop}}
             System.out.println(jour);
         }


### PR DESCRIPTION
improvements to rule EC69 (no function calls when declaring for loops)
- removed false positives when method called in initializer of for loop
- removed false positives when using iterator.next() and iterator.hasNext() in for loop